### PR TITLE
修正了iOS11以上系统上图片显示异常的问题

### DIFF
--- a/ESPictureBrowserDemo/ESPictureBrowserDemo/ESPictureBrowser/ESPictureView.h
+++ b/ESPictureBrowserDemo/ESPictureBrowserDemo/ESPictureBrowser/ESPictureView.h
@@ -21,6 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+// 本程序会在iOS11以上的版本上发生内容下移20(非全面屏)或者64(全面屏)的问题,解决方案参照:
+//  https://www.jianshu.com/p/efbc8619d56b
+
 #import <UIKit/UIKit.h>
 #import <YYImage/YYAnimatedImageView.h>
 

--- a/ESPictureBrowserDemo/ESPictureBrowserDemo/ESPictureBrowser/ESPictureView.m
+++ b/ESPictureBrowserDemo/ESPictureBrowserDemo/ESPictureBrowser/ESPictureView.m
@@ -62,6 +62,12 @@
     self.showsVerticalScrollIndicator = false;
     self.maximumZoomScale = 2;
     
+    // 解决在iOS11以上会造成的内容与SafeArea冲突导致被下移了20(非全面屏)或者64(全面屏)的问题 LH20190423
+    if(@available(iOS 11.0, *))
+        if ([self respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
+            self.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+        }
+    
     // 添加 imageView
     YYAnimatedImageView *imageView = [[YYAnimatedImageView alloc] init];
     imageView.clipsToBounds = true;


### PR DESCRIPTION
修正了由于iOS11以上系统版本的SafeArea会导致UIScrollView的内容下移20(非全面屏)或者64(全面屏)的问题.
具体可参照:https://www.jianshu.com/p/efbc8619d56b(或搜索关键词adjustContentInset)